### PR TITLE
boto3 compatibility (merged from jans-forks:fix/382-boto3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-sudo: false
+dist: xenial
+sudo: true
 before_install: openssl version
 env:
   global:
@@ -7,10 +8,11 @@ env:
     - secure: LBSEg/gMj4u4Hrpo3zs6Y/1mTpd2RtcN49mZIFgTdbJ9IhpiNPqcEt647Lz94F9Eses2x2WbNuKqZKZZReY7QLbEzU1m0nN5jlaKrjcG5NR5clNABfFFyhgc0jBikyS4abAG8jc2efeaTrFuQwdoF4sE8YiVrkiVj2X5Xoi6sBk=
   matrix:
     - TOX_SUFFIX="flakes"
-    - TOX_SUFFIX="requests27"
+    - TOX_SUFFIX="requests"
     - TOX_SUFFIX="httplib2"
     - TOX_SUFFIX="boto3"
     - TOX_SUFFIX="urllib3121"
+    - TOX_SUFFIX="urllib3"
     - TOX_SUFFIX="tornado4"
     - TOX_SUFFIX="aiohttp"
 matrix:
@@ -42,30 +44,30 @@ matrix:
   allow_failures:
     - env: TOX_SUFFIX="boto3"
     - env: TOX_SUFFIX="aiohttp"
-      python: "pypy3.5-5.9.0"
+      python: "pypy3.6-7.0"
     - env: TOX_SUFFIX="aiohttp"
-      python: 3.4
+      python: "3.4"
   exclude:
     # Only run flakes on a single Python 2.x and a single 3.x
     - env: TOX_SUFFIX="flakes"
-      python: 3.4
+      python: "3.4"
     - env: TOX_SUFFIX="flakes"
-      python: 3.5
+      python: "3.5"
     - env: TOX_SUFFIX="flakes"
       python: pypy
     - env: TOX_SUFFIX="flakes"
       python: "pypy3.5-5.9.0"
     - env: TOX_SUFFIX="aiohttp"
-      python: 2.7
+      python: "2.7"
     - env: TOX_SUFFIX="aiohttp"
-      python: pypy
+      python: "pypy2.7-7.0"
 python:
-- 2.7
-- 3.4
-- 3.5
-- 3.6
-- pypy
-- "pypy3.5-5.9.0"
+  - "2.7"
+  - "3.4"
+  - "3.6"
+  - "3.7"
+  - "pypy2.7-7.0"
+  - "pypy3.6-7.0"
 install:
 - pip install tox-travis
 - if [[ $TOX_SUFFIX != 'flakes' ]]; then python setup.py install ; fi

--- a/tests/fixtures/migration/new_cassette.yaml
+++ b/tests/fixtures/migration/new_cassette.yaml
@@ -9,7 +9,7 @@ interactions:
     method: GET
     uri: http://httpbin.org/ip
   response:
-    body: {string: !!python/unicode "{\n  \"origin\": \"217.122.164.194\"\n}"}
+    body: {string: "{\n  \"origin\": \"217.122.164.194\"\n}"}
     headers:
       access-control-allow-origin: ['*']
       content-type: [application/json]

--- a/tests/integration/test_boto3.py
+++ b/tests/integration/test_boto3.py
@@ -1,15 +1,46 @@
 import pytest
+import os
+
 boto3 = pytest.importorskip("boto3")
 
 import boto3  # NOQA
+import botocore  # NOQA
 import vcr  # NOQA
 
-bucket = 'boto3-demo-1337'              # a bucket you can access
-key = 'test/my_test.txt'                # key with r+w access
-content = 'hello world i am a string'   # content to put in the test file
+ses = boto3.Session(
+    aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+    aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+    aws_session_token=None,
+    region_name=os.environ['AWS_DEFAULT_REGION'],
+    # botocore_session=None,
+    # profile_name=None
+)
+
+IAM_CLIENT = ses.client('iam')
+
+try:
+    from botocore import awsrequest  # NOQA
+
+    botocore_awsrequest = True
+except ImportError:
+    botocore_awsrequest = False
 
 
-def test_boto_stubs(tmpdir):
+# skip tests if boto does not use vendored requests anymore
+# https://github.com/boto/botocore/pull/1495
+boto3_skip_vendored_requests = pytest.mark.skipif(
+    botocore_awsrequest,
+    reason='botocore version {ver} does not use vendored requests anymore.'.format(
+        ver=botocore.__version__))
+
+boto3_skip_awsrequest = pytest.mark.skipif(
+    not botocore_awsrequest,
+    reason='botocore version {ver} still uses vendored requests.'.format(
+        ver=botocore.__version__))
+
+
+@boto3_skip_vendored_requests
+def test_boto_vendored_stubs(tmpdir):
     with vcr.use_cassette(str(tmpdir.join('boto3-stubs.yml'))):
         # Perform the imports within the patched context so that
         # HTTPConnection, VerifiedHTTPSConnection refers to the patched version.
@@ -23,45 +54,59 @@ def test_boto_stubs(tmpdir):
         VerifiedHTTPSConnection('hostname.does.not.matter')
 
 
+@boto3_skip_awsrequest
+def test_boto3_awsrequest_stubs(tmpdir):
+    with vcr.use_cassette(str(tmpdir.join('boto3-stubs.yml'))):
+        from botocore.awsrequest import AWSHTTPConnection, AWSHTTPSConnection
+        from vcr.stubs.boto3_stubs import VCRRequestsHTTPConnection, VCRRequestsHTTPSConnection
+        assert issubclass(VCRRequestsHTTPConnection, AWSHTTPConnection)
+        assert issubclass(VCRRequestsHTTPSConnection, AWSHTTPSConnection)
+        AWSHTTPConnection('hostname.does.not.matter')
+        AWSHTTPSConnection('hostname.does.not.matter')
+
+
 def test_boto3_without_vcr():
-    s3_resource = boto3.resource('s3')
-    b = s3_resource.Bucket(bucket)
-    b.put_object(Key=key, Body=content)
+    username = 'user'
+    response = IAM_CLIENT.get_user(UserName=username)
 
-    # retrieve content to check it
-    o = s3_resource.Object(bucket, key).get()
-
-    # decode for python3
-    assert content == o['Body'].read().decode('utf-8')
+    assert response['User']['UserName'] == username
 
 
 def test_boto_medium_difficulty(tmpdir):
-    s3_resource = boto3.resource('s3')
-    b = s3_resource.Bucket(bucket)
+    username = 'user'
+
     with vcr.use_cassette(str(tmpdir.join('boto3-medium.yml'))):
-        b.put_object(Key=key, Body=content)
-        o = s3_resource.Object(bucket, key).get()
-        assert content == o['Body'].read().decode('utf-8')
+        response = IAM_CLIENT.get_user(UserName=username)
+        assert response['User']['UserName'] == username
 
     with vcr.use_cassette(str(tmpdir.join('boto3-medium.yml'))) as cass:
-        b.put_object(Key=key, Body=content)
-        o = s3_resource.Object(bucket, key).get()
-        assert content == o['Body'].read().decode('utf-8')
+        response = IAM_CLIENT.get_user(UserName=username)
+        assert response['User']['UserName'] == username
         assert cass.all_played
 
 
 def test_boto_hardcore_mode(tmpdir):
+    username = 'user'
     with vcr.use_cassette(str(tmpdir.join('boto3-hardcore.yml'))):
-        s3_resource = boto3.resource('s3')
-        b = s3_resource.Bucket(bucket)
-        b.put_object(Key=key, Body=content)
-        o = s3_resource.Object(bucket, key).get()
-        assert content == o['Body'].read().decode('utf-8')
+        ses = boto3.Session(
+            aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+            aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+            region_name=os.environ['AWS_DEFAULT_REGION'],
+        )
+
+        iam_client = ses.client('iam')
+        response = iam_client.get_user(UserName=username)
+        assert response['User']['UserName'] == username
 
     with vcr.use_cassette(str(tmpdir.join('boto3-hardcore.yml'))) as cass:
-        s3_resource = boto3.resource('s3')
-        b = s3_resource.Bucket(bucket)
-        b.put_object(Key=key, Body=content)
-        o = s3_resource.Object(bucket, key).get()
-        assert content == o['Body'].read().decode('utf-8')
+        ses = boto3.Session(
+            aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+            aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+            aws_session_token=None,
+            region_name=os.environ['AWS_DEFAULT_REGION'],
+        )
+
+        iam_client = ses.client('iam')
+        response = iam_client.get_user(UserName=username)
+        assert response['User']['UserName'] == username
         assert cass.all_played

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -22,9 +22,9 @@ def test_try_migrate_with_yaml(tmpdir):
     shutil.copy('tests/fixtures/migration/old_cassette.yaml', cassette)
     assert vcr.migration.try_migrate(cassette)
     with open('tests/fixtures/migration/new_cassette.yaml', 'r') as f:
-        expected_yaml = yaml.load(f)
+        expected_yaml = yaml.safe_load(f)
     with open(cassette, 'r') as f:
-        actual_yaml = yaml.load(f)
+        actual_yaml = yaml.safe_load(f)
     assert actual_yaml == expected_yaml
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37,pypy}-{flakes,requests27,httplib2,urllib3121,tornado4,boto3,aiohttp}
+envlist = {py27,py34,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3121,urllib3,tornado4,boto3,aiohttp}
 
 [testenv:flakes]
 skipsdist = True
@@ -13,14 +13,15 @@ deps = flake8
 commands =
     ./runtests.sh {posargs}
 deps =
-    Flask<1
+    Flask
     mock
     pytest
     pytest-httpbin
     PyYAML
-    requests27: requests==2.7.0
+    requests: requests
     httplib2: httplib2
     urllib3121: urllib3==1.21.1
+    urllib3: urllib3
     {py27,py35,py36,pypy}-tornado4: tornado>=4,<5
     {py27,py35,py36,pypy}-tornado4: pytest-tornado
     {py27,py35,py36}-tornado4: pycurl
@@ -28,6 +29,9 @@ deps =
     aiohttp: aiohttp
     aiohttp: pytest-asyncio
     aiohttp: pytest-aiohttp
-
+passenv =
+    AWS_ACCESS_KEY_ID
+    AWS_DEFAULT_REGION
+    AWS_SECRET_ACCESS_KEY
 [flake8]
 max_line_length = 110

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -190,6 +190,7 @@ class Cassette(object):
         self._serializer = serializer or yamlserializer
         self._match_on = match_on
         self._before_record_request = before_record_request or (lambda x: x)
+        log.info(self._before_record_request)
         self._before_record_response = before_record_response or (lambda x: x)
         self.inject = inject
         self.record_mode = record_mode
@@ -225,6 +226,7 @@ class Cassette(object):
 
     def append(self, request, response):
         """Add a request, response pair to this cassette"""
+        log.info("Appending request %s and response %s", request, response)
         request = self._before_record_request(request)
         if not request:
             return

--- a/vcr/request.py
+++ b/vcr/request.py
@@ -2,6 +2,9 @@ import warnings
 from six import BytesIO, text_type
 from six.moves.urllib.parse import urlparse, parse_qsl
 from .util import CaseInsensitiveDict
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class Request(object):
@@ -18,6 +21,7 @@ class Request(object):
         else:
             self.body = body
         self.headers = headers
+        log.debug("Invoking Request %s", self.uri)
 
     @property
     def headers(self):

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -145,6 +145,7 @@ class VCRConnection(object):
             self._port_postfix(),
             url,
         )
+        log.debug("Absolute URI: %s", uri)
         return uri
 
     def _url(self, uri):

--- a/vcr/stubs/boto3_stubs.py
+++ b/vcr/stubs/boto3_stubs.py
@@ -1,10 +1,20 @@
-'''Stubs for boto3'''
+"""Stubs for boto3"""
 
-from botocore.vendored.requests.packages.urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+try:
+    # boto using awsrequest
+    from botocore.awsrequest import AWSHTTPConnection as HTTPConnection
+    from botocore.awsrequest import AWSHTTPSConnection as VerifiedHTTPSConnection
+
+except ImportError:  # pragma: nocover
+    # boto using vendored requests
+    # urllib3 defines its own HTTPConnection classes, which boto3 goes ahead and assumes
+    # you're using.  It includes some polyfills for newer features missing in older pythons.
+    try:
+        from urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+    except ImportError:  # pragma: nocover
+        from requests.packages.urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+
 from ..stubs import VCRHTTPConnection, VCRHTTPSConnection
-
-# urllib3 defines its own HTTPConnection classes, which boto3 goes ahead and assumes
-# you're using.  It includes some polyfills for newer features missing in older pythons.
 
 
 class VCRRequestsHTTPConnection(VCRHTTPConnection, HTTPConnection):


### PR DESCRIPTION
* Add support for PyYaml5.1
* Unpin requests in Tox
* Unpin urllib3 in Tox
* Unpin Flask in Tox
* Add env vars to Tox for boto3 tests